### PR TITLE
Indexing str with StrRange

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,12 @@ readme = "README.md"
 keywords = ["span","codespan","compiler","source"]
 categories = ["data-structures","no-std","parsing","rust-patterns"]
 
+[features]
+default = ["alloc"]
+alloc = ["serde/alloc"]
+
 [dependencies]
-serde = { version = "1.0", optional = true }
+serde = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 use core::u32;
 
 mod convert;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,6 +1,6 @@
 use {
-    crate::StrIndex,
-    core::ops::{Add, AddAssign, Sub, SubAssign},
+    crate::{StrIndex, StrRange},
+    core::ops::{Add, AddAssign, Index, IndexMut, Sub, SubAssign},
 };
 
 macro_rules! math {
@@ -51,4 +51,51 @@ where
     fn sub_assign(&mut self, rhs: Rhs) {
         *self = *self - rhs;
     }
+}
+
+impl Index<StrRange> for str {
+    type Output = str;
+
+    fn index(&self, index: StrRange) -> &str {
+        &self[index.start().into()..index.end().into()]
+    }
+}
+
+impl IndexMut<StrRange> for str {
+    fn index_mut(&mut self, index: StrRange) -> &mut Self::Output {
+        &mut self[index.start().into()..index.end().into()]
+    }
+}
+
+#[cfg(feature = "alloc")]
+mod for_alloc_types {
+    use {super::*, alloc::string::String};
+
+    impl Index<StrRange> for String {
+        type Output = str;
+        fn index(&self, index: StrRange) -> &str {
+            &self[..][index]
+        }
+    }
+
+    impl IndexMut<StrRange> for String {
+        fn index_mut(&mut self, index: StrRange) -> &mut Self::Output {
+            &mut self[..][index]
+        }
+    }
+
+    #[test]
+    fn string_indexing() {
+        let range = StrRange::between(0.into(), 5.into());
+        let s = String::from("swordfish");
+        assert_eq!(&s[range], "sword");
+    }
+}
+
+#[test]
+#[allow(clippy::no_effect)]
+fn str_indexing() {
+    let range = StrRange::between(0.into(), 5.into());
+    let s = "swordfish";
+    assert_eq!(&s[range], "sword");
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,13 +1,10 @@
-extern crate std;
-use std::prelude::v1::*;
-
 use {
     super::{StrIndex, StrRange},
+    core::fmt,
     serde::{
         de::{Deserialize, Deserializer, Error, MapAccess, SeqAccess, Visitor},
         ser::{Serialize, SerializeStruct, Serializer},
     },
-    std::fmt,
 };
 
 impl Serialize for StrIndex {
@@ -193,7 +190,7 @@ impl<'de> Visitor<'de> for StrRangeFieldVisitor {
             b"start" => Ok(StrRangeField::Start),
             b"end" => Ok(StrRangeField::End),
             _ => {
-                let value = String::from_utf8_lossy(value);
+                let value = serde::export::from_utf8_lossy(value);
                 Err(Error::unknown_field(&value, STR_RANGE_FIELDS))
             }
         }


### PR DESCRIPTION
`Index<ops::Range<StrIndex>> for str` is impossible, I think.

This also fixes the `serde` feature to properly not depend on `serde/std`, and adds an `alloc` feature for `Index for String` impls.