### PR TITLE
From<ops::Range> for StrRange

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,6 +1,9 @@
 use {
-    crate::StrIndex,
-    core::convert::{TryFrom, TryInto},
+    crate::{StrIndex, StrRange},
+    core::{
+        convert::{TryFrom, TryInto},
+        ops::{Range, RangeTo},
+    },
 };
 
 impl From<StrIndex> for u32 {
@@ -25,5 +28,23 @@ impl TryFrom<usize> for StrIndex {
     type Error = <usize as TryInto<u32>>::Error;
     fn try_from(i: usize) -> Result<Self, Self::Error> {
         i.try_into().map(|raw| StrIndex { raw })
+    }
+}
+
+impl From<Range<StrIndex>> for StrRange {
+    fn from(range: Range<StrIndex>) -> Self {
+        let Range { start, end } = range;
+        let range = StrRange { start, end };
+        assert!(start <= end, "invalid string range {}", range);
+        range
+    }
+}
+
+impl From<RangeTo<StrIndex>> for StrRange {
+    fn from(range: RangeTo<StrIndex>) -> Self {
+        StrRange {
+            start: 0.into(),
+            end: range.end,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,33 @@ impl StrIndex {
 }
 
 /// A range of a string, represented as a half-open range of `StrIndex`.
+///
+/// Construct a `StrRange` by using `from` conversion from `std::ops::Range`/`RangeTo`.
+/// The range is always guaranteed increasing; conversion panics if `end < start`.
+///
+/// # Examples
+///
+/// ```rust
+/// # use str_index::{StrRange, StrIndex};
+/// let zero = StrIndex::from(0);
+/// let start = StrIndex::from(10);
+/// let end = StrIndex::from(20);
+/// assert_eq!(
+///     format!("{:?}", StrRange::from(start..end)),
+///     format!("{:?}", start..end),
+/// );
+/// assert_eq!(
+///     format!("{:?}", StrRange::from(..end)),
+///     format!("{:?}", zero..end),
+/// );
+/// ```
+///
+/// ```rust,should_panic
+/// # use str_index::{StrRange, StrIndex};
+/// # let start = StrIndex::from(10);
+/// # let end = StrIndex::from(20);
+/// let this_panics = StrRange::from(end..start);
+/// ```
 #[derive(Copy, Clone, Default, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct StrRange {
     start: StrIndex,
@@ -75,28 +102,6 @@ pub struct StrRange {
 }
 
 impl StrRange {
-    /// The half-open range (`start..end`) between two points in a string.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use str_index::*;
-    /// let range = StrRange::between(0.into(), 10.into());
-    /// assert_eq!(
-    ///     format!("{:?}", range),
-    ///     "0..10".to_string(),
-    /// );
-    ///
-    /// // An empty unit range is also valid:
-    ///
-    /// StrRange::between(0.into(), 0.into());
-    /// ```
-    pub fn between(start: StrIndex, end: StrIndex) -> Self {
-        let range = StrRange { start, end };
-        assert!(start <= end, "invalid string range {}", range);
-        range
-    }
-
     /// The (inclusive) start index of this range.
     pub fn start(self) -> StrIndex {
         self.start

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -12,8 +12,9 @@ fn str_index() {
 
 #[test]
 fn str_range() {
+    let range = StrRange::from(StrIndex::from(0)..StrIndex::from(10));
     assert_tokens(
-        &StrRange::between(0.into(), 10.into()),
+        &range,
         &[
             Token::Struct {
                 name: "StrRange",
@@ -29,7 +30,7 @@ fn str_range() {
         ],
     );
     assert_de_tokens(
-        &StrRange::between(0.into(), 10.into()),
+        &range,
         &[
             Token::Map { len: Some(2) },
             Token::Str("start"),
@@ -40,7 +41,7 @@ fn str_range() {
         ],
     );
     assert_de_tokens(
-        &StrRange::between(0.into(), 10.into()),
+        &range,
         &[
             Token::Seq { len: Some(2) },
             Token::U32(0),


### PR DESCRIPTION
This is an alternate construction method to `::between` that I think is better but deserves its own review outside of #1.